### PR TITLE
Potential fix for code scanning alert no. 12: Log injection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -463,7 +463,8 @@ export function sanitizeForLogging(url: string | undefined, query?: unknown): st
     url = "";
   }
 
-  let sanitized = url;
+  // Remove any CR, LF characters to prevent log injection
+  let sanitized = url.replace(/[\r\n]/g, "");
 
   // Mask sensitive query parameters in URL
   const sensitiveParams = ["apiKey", "token", "api_key", "auth", "authorization"];


### PR DESCRIPTION
Potential fix for [https://github.com/meloncafe/chromadb-remote-mcp/security/code-scanning/12](https://github.com/meloncafe/chromadb-remote-mcp/security/code-scanning/12)

The correct way to fix this problem is to ensure that any user input included in log entries—specifically the URL in this case—does not contain log control characters, particularly newlines (`\n` and `\r`). This can be accomplished by updating the `sanitizeForLogging` function so that, in addition to masking sensitive query parameters, it also removes or replaces all newline and carriage return characters from the `url` string before it is returned or concatenated into a log message.

Specifically, inside `sanitizeForLogging`, immediately after handling undefined/null values, apply `.replace(/\r|\n/g, "")` to the `url`. For thoroughness, also ensure that any serialized query parameter representations are sanitized before being concatenated/returned.

No additional libraries are required for this operation—`String.prototype.replace` with regex is sufficient. All changes should be made inside `src/index.ts` in the implementation of `sanitizeForLogging`. No changes to the log statement or the proxy handler itself are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
