### PR TITLE
Potential fix for code scanning alert no. 6: Log injection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1388,7 +1388,7 @@ export async function mcpHandler(req: express.Request, res: express.Response) {
   const sanitizedMethod = sanitizeLogValue(req.body?.method || "unknown");
 
   // Use MCP logging for request tracking
-  await mcpLog.info(`Received MCP request: ${sanitizedMethod}`, {
+  await mcpLog.info(`Received MCP request (from user): '${sanitizedMethod}'`, {
     url: sanitizedUrl,
     method: sanitizedMethod,
   });


### PR DESCRIPTION
Potential fix for [https://github.com/meloncafe/chromadb-remote-mcp/security/code-scanning/6](https://github.com/meloncafe/chromadb-remote-mcp/security/code-scanning/6)

We must ensure that *all* user-supplied input in log messages is explicitly marked as user-controlled, particularly the `method` passed in the log message. This can be achieved using textual prefixes/suffixes (such as quoting and clarifying "from user") in the log output, making it unambiguous.

**How to fix:**
- In the log message `"Received MCP request: ${sanitizedMethod}"`, change it to `"Received MCP request (from user): '${sanitizedMethod}'"`, thereby making it clear that the value is user-controlled.
- Only update the log message line where user input is shown directly in a human-readable string; do *not* change backend storage or logic elsewhere.

**Specific changes required:**
- In `src/index.ts`, on line 1391: update the log message string to explicitly mark the user-controlled value.

No additional methods or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
